### PR TITLE
Raise MIN_SUPPORTED_SONAR_RUNTIME_JAVA_VERSION to 21

### DIFF
--- a/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintConstants.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintConstants.java
@@ -8,6 +8,6 @@ import org.gradle.api.JavaVersion;
 @NoArgsConstructor(access = PRIVATE)
 abstract class SonarLintConstants {
 
-    public static final JavaVersion MIN_SUPPORTED_SONAR_RUNTIME_JAVA_VERSION = JavaVersion.VERSION_17;
+    public static final JavaVersion MIN_SUPPORTED_SONAR_RUNTIME_JAVA_VERSION = JavaVersion.VERSION_21;
 
 }


### PR DESCRIPTION
## Summary

Raise the minimum Java version of the forked SonarLint runtime JVM from 17 to 21. Required by `org.sonarsource.sonarlint.core` v11+, which is compiled to Java 21 bytecode (class file v65) and fails on Java 17 with `UnsupportedClassVersionError`.