### PR TITLE
Add failOnSeverity setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Also, a single frontend language can be included like this: `sonarLint.languages
 sonarLint {
   isGeneratedCodeIgnored = false // `true` by default, set to `false` to validate generated code (code inside `./build/`)
 
+  // Build fails only on issues at or above this severity. Allowed: 'ERROR', 'WARNING', 'INFO'.
+  // When unset (default), every issue fails the build.
+  // All issues are still logged and written to XML/HTML reports regardless of this setting.
+  failOnSeverity('WARNING')
+
   rules {
     enable(
       'java:S100', // Enable `java:S100` rule (that is disabled by default)

--- a/src/functionalTest/java/name/remal/gradle_plugins/sonarlint/SonarLintPluginFunctionalTest.java
+++ b/src/functionalTest/java/name/remal/gradle_plugins/sonarlint/SonarLintPluginFunctionalTest.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -282,6 +283,42 @@ class SonarLintPluginFunctionalTest {
                     .assertBuildOutput(output ->
                         assertThat(output)
                             .doesNotContain("\n  Why is this an issue?\n")
+                    );
+            }
+
+        }
+
+
+        @Nested
+        class FailOnSeverity {
+
+            @BeforeEach
+            void beforeEach() {
+                project.getBuildFile().line("sonarLint.ignoreFailures = false");
+            }
+
+            @Test
+            void buildFailsByDefault() {
+                new Assertions()
+                    .rule("java:S100")
+                    .expectFailedBuild()
+                    .assertAllRulesAreRaised()
+                    .assertBuildOutput(output ->
+                        assertThat(output)
+                            .contains("java:S100")
+                    );
+            }
+
+            @Test
+            void buildSucceedsAndIssueIsLoggedWhenSeverityBelowThreshold() {
+                project.getBuildFile().line("sonarLint.failOnSeverity('error')");
+
+                new Assertions()
+                    .rule("java:S100")
+                    .assertAllRulesAreRaised()
+                    .assertBuildOutput(output ->
+                        assertThat(output)
+                            .contains("java:S100")
                     );
             }
 
@@ -668,9 +705,15 @@ class SonarLintPluginFunctionalTest {
     @SuppressWarnings("UnusedReturnValue")
     class Assertions {
 
-        private final LazyValue<BuildResult> buildResult = lazyValue(() ->
-            project.assertBuildSuccessfully("sonarlintMain")
-        );
+        private final AtomicBoolean expectSuccess = new AtomicBoolean(true);
+
+        private final LazyValue<BuildResult> buildResult = lazyValue(() -> {
+            if (expectSuccess.get()) {
+                return project.assertBuildSuccessfully("sonarlintMain");
+            } else {
+                return project.assertBuildFails("sonarlintMain");
+            }
+        });
 
         private final Set<String> writtenRuleExamples = new LinkedHashSet<>();
 
@@ -699,6 +742,15 @@ class SonarLintPluginFunctionalTest {
             return this;
         }
 
+
+        @CanIgnoreReturnValue
+        public Assertions expectFailedBuild() {
+            if (buildResult.isInitialized()) {
+                throw new IllegalStateException("Project has been built");
+            }
+            expectSuccess.set(false);
+            return this;
+        }
 
         @CanIgnoreReturnValue
         public Assertions assertBuildOutput(Consumer<String> outputVerifier) {

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLint.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLint.java
@@ -438,6 +438,7 @@ public abstract class SonarLint extends AbstractSonarLintTask
 
 
         params.getIsIgnoreFailures().set(getIgnoreFailures());
+        params.getFailOnSeverity().set(settings.getFailOnSeverity());
         params.getWithDescription().set(settings.getLogging().getWithDescription());
         params.getXmlReportLocation().fileProvider(getSonarLintReportFile(SonarLintReports::getXml));
         params.getHtmlReportLocation().fileProvider(getSonarLintReportFile(SonarLintReports::getHtml));

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintAnalyzeWorkAction.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintAnalyzeWorkAction.java
@@ -2,6 +2,7 @@ package name.remal.gradle_plugins.sonarlint;
 
 import static java.lang.String.format;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static lombok.AccessLevel.PUBLIC;
 import static name.remal.gradle_plugins.toolkit.ObjectUtils.unwrapProviders;
 import static name.remal.gradle_plugins.toolkit.PathUtils.tryToDeleteRecursivelyIgnoringFailure;
@@ -28,6 +29,7 @@ import name.remal.gradle_plugins.toolkit.CloseablesContainer;
 import name.remal.gradle_plugins.toolkit.issues.CheckstyleHtmlIssuesRenderer;
 import name.remal.gradle_plugins.toolkit.issues.CheckstyleXmlIssuesRenderer;
 import name.remal.gradle_plugins.toolkit.issues.Issue;
+import name.remal.gradle_plugins.toolkit.issues.IssueSeverity;
 import name.remal.gradle_plugins.toolkit.issues.TextIssuesRenderer;
 import org.jspecify.annotations.Nullable;
 
@@ -133,10 +135,38 @@ abstract class SonarLintAnalyzeWorkAction
             );
 
             if (!params.getIsIgnoreFailures().get()) {
-                throw newVerificationException(format(
-                    "SonarLint analysis failed with %d issues",
-                    issues.size()
-                ));
+                var threshold = params.getFailOnSeverity().getOrNull();
+                final Collection<Issue> failingIssues;
+                if (threshold == null) {
+                    failingIssues = issues;
+                } else {
+                    var thresholdAsToolkit = IssueSeverity.valueOf(threshold.name());
+                    failingIssues = issues.stream()
+                        .filter(issue -> {
+                            // null severity is treated as "always fails": the issue may have come
+                            // from a rule with no impacts mapping, and silently passing such an
+                            // issue would mask real problems.
+                            var severity = issue.getSeverity();
+                            return severity == null || severity.compareTo(thresholdAsToolkit) <= 0;
+                        })
+                        .collect(toUnmodifiableList());
+                }
+
+                if (!failingIssues.isEmpty()) {
+                    if (failingIssues.size() == issues.size()) {
+                        throw newVerificationException(format(
+                            "SonarLint analysis failed with %d issues",
+                            failingIssues.size()
+                        ));
+                    } else {
+                        throw newVerificationException(format(
+                            "SonarLint analysis failed with %d of %d issues at or above severity %s",
+                            failingIssues.size(),
+                            issues.size(),
+                            threshold
+                        ));
+                    }
+                }
             }
         }
     }

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintAnalyzeWorkActionParams.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintAnalyzeWorkActionParams.java
@@ -31,6 +31,8 @@ interface SonarLintAnalyzeWorkActionParams extends AbstractSonarLintTaskWorkActi
 
     Property<Boolean> getIsIgnoreFailures();
 
+    Property<SonarLintIssueSeverity> getFailOnSeverity();
+
     Property<Boolean> getWithDescription();
 
     RegularFileProperty getXmlReportLocation();

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintIssueSeverity.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintIssueSeverity.java
@@ -1,0 +1,19 @@
+package name.remal.gradle_plugins.sonarlint;
+
+/**
+ * Severity levels for SonarLint issues, ordered from most to least severe.
+ *
+ * <p>The declaration order is significant: it defines the threshold comparison used by
+ * {@link SonarLintSettings#getFailOnSeverity()}. An issue with severity X fails the build
+ * if {@code X.compareTo(threshold) <= 0}, so {@link #ERROR} must remain first and
+ * {@link #INFO} last.
+ */
+public enum SonarLintIssueSeverity {
+
+    ERROR,
+
+    WARNING,
+
+    INFO,
+
+}

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintSettings.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/SonarLintSettings.java
@@ -8,6 +8,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
+import org.jspecify.annotations.Nullable;
 
 public abstract class SonarLintSettings {
 
@@ -16,6 +17,20 @@ public abstract class SonarLintSettings {
 
     {
         getIgnoreFailures().convention(false);
+    }
+
+
+    @Input
+    @org.gradle.api.tasks.Optional
+    public abstract Property<SonarLintIssueSeverity> getFailOnSeverity();
+
+    public void failOnSeverity(@Nullable Object severity) {
+        if (severity == null) {
+            getFailOnSeverity().unset();
+            return;
+        }
+
+        getFailOnSeverity().set(SonarLintIssueSeverity.valueOf(severity.toString().toUpperCase()));
     }
 
 

--- a/src/testFixtures/java/name/remal/gradle_plugins/sonarlint/RuleExamples.java
+++ b/src/testFixtures/java/name/remal/gradle_plugins/sonarlint/RuleExamples.java
@@ -62,7 +62,7 @@ public abstract class RuleExamples {
             "",
             "public class JavaS1133 {",
             "",
-            "    @Deprecated",
+            "    @Deprecated(forRemoval=true)",
             "    void method() {",
             "        System.exit(1);",
             "    }",


### PR DESCRIPTION
## Summary

Closes #775. Adds an opt-in `failOnSeverity` setting that fails the build only when at least one issue is at or above the configured severity. Issues below the threshold are still logged and written to XML/HTML reports. Default (unset) preserves current behavior of failing on any issue.