### PR TITLE
Replace ProcessHandle-based parent monitoring with heartbeat

### DIFF
--- a/src/main/java/name/remal/gradle_plugins/sonarlint/internal/client/SonarLintClient.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/internal/client/SonarLintClient.java
@@ -51,6 +51,7 @@ import name.remal.gradle_plugins.sonarlint.internal.client.api.SonarLintServerRu
 import name.remal.gradle_plugins.sonarlint.internal.server.ImmutableSonarLintServerParams;
 import name.remal.gradle_plugins.sonarlint.internal.server.SonarLintServerMain;
 import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintAnalyzer;
+import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintHeartbeat;
 import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintHelp;
 import name.remal.gradle_plugins.sonarlint.internal.utils.AccumulatingLogger;
 import name.remal.gradle_plugins.sonarlint.internal.utils.ServerRegistryFacade;
@@ -290,6 +291,35 @@ public class SonarLintClient extends AbstractCloseablesContainer implements Auto
                 close();
             }
         }
+
+        startHeartbeat();
+    }
+
+
+    private static final Duration HEARTBEAT_PING_INTERVAL = Duration.ofSeconds(5);
+
+    @SuppressWarnings("BusyWait")
+    private void startHeartbeat() {
+        var startedState = (Started) state;
+        SonarLintHeartbeat heartbeat = startedState.getServerRegistry().lookup(SonarLintHeartbeat.class);
+
+        var heartbeatThread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(HEARTBEAT_PING_INTERVAL.toMillis());
+                    heartbeat.ping();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (Exception e) {
+                    break;
+                }
+            }
+        });
+        heartbeatThread.setName(SonarLintClient.class.getSimpleName() + "-heartbeat");
+        heartbeatThread.setDaemon(true);
+        registerCloseable(heartbeatThread::interrupt);
+        heartbeatThread.start();
     }
 
     @SuppressWarnings("java:S2259")
@@ -350,15 +380,9 @@ public class SonarLintClient extends AbstractCloseablesContainer implements Auto
     @SneakyThrows
     @SuppressWarnings("java:S5443")
     private JavaExecProcess startServer(ServerRegistryFacade serverRuntimeInfoRegistry) {
-        var clientPid = ProcessHandle.current().pid();
-        var clientStartInstant = ProcessHandle.current().info().startInstant();
-        logger.info("Client PID: %d, start instant: %s", clientPid, clientStartInstant);
-
         var serverParams = ImmutableSonarLintServerParams.builder()
             .from(params)
             .loopbackAddress(loopbackAddress)
-            .clientPid(clientPid)
-            .clientStartInstant(clientStartInstant)
             .serverRuntimeInfoSocketAddress(serverRuntimeInfoRegistry.getSocketAddress())
             .build();
 

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintHeartbeatDefault.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintHeartbeatDefault.java
@@ -1,0 +1,24 @@
+package name.remal.gradle_plugins.sonarlint.internal.server;
+
+import static java.lang.System.nanoTime;
+
+import java.rmi.RemoteException;
+import java.time.Duration;
+import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintHeartbeat;
+
+class SonarLintHeartbeatDefault implements SonarLintHeartbeat {
+
+    private static final Duration TIMEOUT = Duration.ofMinutes(15);
+
+    private volatile long lastPingNanos = nanoTime();
+
+    @Override
+    public void ping() throws RemoteException {
+        lastPingNanos = nanoTime();
+    }
+
+    public boolean isTimedOut() {
+        return nanoTime() - lastPingNanos > TIMEOUT.toNanos();
+    }
+
+}

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintServer.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintServer.java
@@ -16,6 +16,7 @@ import name.remal.gradle_plugins.sonarlint.internal.server.SonarLintServerState.
 import name.remal.gradle_plugins.sonarlint.internal.server.SonarLintServerState.Started;
 import name.remal.gradle_plugins.sonarlint.internal.server.SonarLintServerState.Stopped;
 import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintAnalyzer;
+import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintHeartbeat;
 import name.remal.gradle_plugins.sonarlint.internal.server.api.SonarLintHelp;
 import name.remal.gradle_plugins.toolkit.AbstractCloseablesContainer;
 import org.slf4j.Logger;
@@ -31,6 +32,13 @@ public class SonarLintServer
 
 
     private final SonarLintServerParams params;
+
+
+    private volatile SonarLintHeartbeatDefault heartbeat;
+
+    public SonarLintHeartbeatDefault getHeartbeat() {
+        return heartbeat;
+    }
 
 
     private volatile SonarLintServerState state = SERVER_CREATED;
@@ -101,6 +109,15 @@ public class SonarLintServer
             help = usedThreads.withRegisterThreadEveryCall(SonarLintHelp.class, help);
             help = withServerExceptionCalls(SonarLintHelp.class, help);
             registry.bind(SonarLintHelp.class, help);
+        }
+
+        {
+            heartbeat = new SonarLintHeartbeatDefault();
+            SonarLintHeartbeat heartbeatRmi = withServerExceptionCalls(
+                SonarLintHeartbeat.class,
+                heartbeat
+            );
+            registry.bind(SonarLintHeartbeat.class, heartbeatRmi);
         }
 
 

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintServerMain.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintServerMain.java
@@ -8,7 +8,6 @@ import static name.remal.gradle_plugins.sonarlint.internal.utils.JacocoUtils.dum
 import static name.remal.gradle_plugins.sonarlint.internal.utils.LogMessageRenderer.SIMPLE_LOG_MESSAGE_DATE_FORMAT;
 import static name.remal.gradle_plugins.sonarlint.internal.utils.RegistryFactory.connectToRegistry;
 import static name.remal.gradle_plugins.toolkit.JavaSerializationUtils.deserializeFrom;
-import static name.remal.gradle_plugins.toolkit.SneakyThrowUtils.sneakyThrowsRunnable;
 
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -22,7 +21,7 @@ import org.slf4j.event.Level;
 
 public class SonarLintServerMain {
 
-    private static final Duration PARENT_START_INSTANT_TOLERANCE = Duration.ofSeconds(5);
+    private static final Duration HEARTBEAT_CHECK_INTERVAL = Duration.ofSeconds(5);
 
     @SneakyThrows
     public static void main(String[] args) {
@@ -97,7 +96,7 @@ public class SonarLintServerMain {
             server.start();
 
 
-            monitorParentProcessExit(serverParams, () -> stopServer(server));
+            startHeartbeatWatchdog(server, () -> stopServer(server));
 
             logger.info(
                 "Reporting {} RMI registry socket address back to the client: {}",
@@ -121,52 +120,28 @@ public class SonarLintServerMain {
         logger.info("Stopped server");
     }
 
-    private static void monitorParentProcessExit(SonarLintServerParams serverParams, Runnable onExit) {
+    @SuppressWarnings("BusyWait")
+    private static void startHeartbeatWatchdog(SonarLintServer server, Runnable onTimeout) {
         var logger = LoggerFactory.getLogger(SonarLintServerMain.class);
 
-        var clientPid = serverParams.getClientPid();
-        var parentHandle = ProcessHandle.of(clientPid).orElse(null);
-        if (parentHandle == null) {
-            onExit.run();
-            throw new IllegalStateException(format(
-                "Parent process already exited: PID %d not found",
-                clientPid
-            ));
-        }
-
-        logger.info("Parent process PID: {}, info: {}", clientPid, parentHandle.info());
-
-        var clientStartInstant = serverParams.getClientStartInstant().orElse(null);
-        var currentParentStartInstant = parentHandle.info().startInstant().orElse(null);
-        logger.info(
-            "Parent process start instant check: recorded={}, current={}",
-            clientStartInstant,
-            currentParentStartInstant
-        );
-        if (clientStartInstant != null && currentParentStartInstant != null) {
-            var diff = Duration.between(clientStartInstant, currentParentStartInstant).abs();
-            if (diff.compareTo(PARENT_START_INSTANT_TOLERANCE) > 0) {
-                onExit.run();
-                throw new IllegalStateException(format(
-                    "Parent process already exited: start instant diff is %s (recorded=%s, current=%s)",
-                    diff,
-                    clientStartInstant,
-                    currentParentStartInstant
-                ));
+        var watchdog = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(HEARTBEAT_CHECK_INTERVAL.toMillis());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                if (server.getHeartbeat().isTimedOut()) {
+                    logger.info("Heartbeat timeout, shutting down");
+                    onTimeout.run();
+                    return;
+                }
             }
-        } else if (currentParentStartInstant == null) {
-            logger.warn(
-                "Parent process start instant is unavailable (recorded={}, current={}), skipping check",
-                clientStartInstant,
-                currentParentStartInstant
-            );
-        }
-
-        var onExitFuture = parentHandle.onExit().thenRun(onExit);
-        var onExitMonitor = new Thread(sneakyThrowsRunnable(onExitFuture::get));
-        onExitMonitor.setName(SonarLintServerMain.class.getSimpleName() + "-parent-on-exit-monitor");
-        onExitMonitor.setDaemon(true);
-        onExitMonitor.start();
+        });
+        watchdog.setName(SonarLintServerMain.class.getSimpleName() + "-heartbeat-watchdog");
+        watchdog.setDaemon(true);
+        watchdog.start();
     }
 
 }

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintServerParams.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/SonarLintServerParams.java
@@ -4,8 +4,6 @@ import static org.slf4j.event.Level.INFO;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.time.Instant;
-import java.util.Optional;
 import org.immutables.value.Value;
 import org.slf4j.event.Level;
 
@@ -14,10 +12,6 @@ import org.slf4j.event.Level;
 public interface SonarLintServerParams extends SonarLintParams {
 
     InetAddress getLoopbackAddress();
-
-    long getClientPid();
-
-    Optional<Instant> getClientStartInstant();
 
     InetSocketAddress getServerRuntimeInfoSocketAddress();
 

--- a/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/api/SonarLintHeartbeat.java
+++ b/src/main/java/name/remal/gradle_plugins/sonarlint/internal/server/api/SonarLintHeartbeat.java
@@ -1,0 +1,10 @@
+package name.remal.gradle_plugins.sonarlint.internal.server.api;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+public interface SonarLintHeartbeat extends Remote {
+
+    void ping() throws RemoteException;
+
+}


### PR DESCRIPTION
## Summary

`ProcessHandle.onExit()` and `ProcessHandle.info().startInstant()` are unreliable on some platforms, causing the forked SonarLint server to shut down while analyses are still in flight. This replaces the entire `ProcessHandle`-based parent process monitoring with a heartbeat protocol: the client pings the server every 5 seconds over RMI, and the server shuts down if no ping arrives within 15 minutes.

Fixes #894, fixes #909.